### PR TITLE
Bump provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can provide a postman collection and environment to be tested in one of two 
 1. Provided in your github repo
     ```hcl
     module "postman_test_lambda" {
-      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v1.0.1"
+      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.0.0"
         app_name                      = "simple-example"
         postman_collection_file       = "terraform-aws-postman-test-lambda-example.postman_collection.json"
         postman_environment_file      = "terraform-aws-postman-test-lambda-env.postman_environment.json"
@@ -24,7 +24,7 @@ You can provide a postman collection and environment to be tested in one of two 
 2. Or from the Postman API
     ```hcl
     module "postman_test_lambda" {
-      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v1.0.1"
+      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.0.0"
         app_name                      = "simple-example"
         postman_collection_name       = "terraform-aws-postman-test-lambda-example"
         postman_environment_name      = "terraform-aws-postman-test-lambda-env"

--- a/examples/postman-api/postman-api-example.tf
+++ b/examples/postman-api/postman-api-example.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.42"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.42"
+  version = "~> 3.0"
   region  = "us-west-2"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 0.12.16"
   required_providers {
-    aws = ">= 2.42"
+    aws = ">= 3.0.0"
   }
 }
 


### PR DESCRIPTION
Update AWS provider to 3.0.0. Update version to 2.0.0. Successfully applied the example infrastructure.
