### PR TITLE
Add expiration policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can provide a postman collection and environment to be tested in one of two 
 1. Provided in your github repo
     ```hcl
     module "postman_test_lambda" {
-      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.0.0"
+      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.0.1"
         app_name                      = "simple-example"
         postman_collection_file       = "terraform-aws-postman-test-lambda-example.postman_collection.json"
         postman_environment_file      = "terraform-aws-postman-test-lambda-env.postman_environment.json"
@@ -24,7 +24,7 @@ You can provide a postman collection and environment to be tested in one of two 
 2. Or from the Postman API
     ```hcl
     module "postman_test_lambda" {
-      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.0.0"
+      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.0.1"
         app_name                      = "simple-example"
         postman_collection_name       = "terraform-aws-postman-test-lambda-example"
         postman_environment_name      = "terraform-aws-postman-test-lambda-env"

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,11 @@ resource "aws_s3_bucket" "postman_bucket" {
     id                                     = "AutoAbortFailedMultipartUpload"
     enabled                                = true
     abort_incomplete_multipart_upload_days = 10
+
+    expiration {
+      days                         = 0
+      expired_object_delete_marker = false
+    }
   }
   server_side_encryption_configuration {
     rule {


### PR DESCRIPTION
The expiration policy isn't included in the module, so everytime there is a `terraform plan` it will get deleted, then re-added by ACS.
