### PR TITLE
added postman_files_bucket_name optional variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can provide a postman collection and environment to be tested in one of two 
 1. Provided in your github repo
     ```hcl
     module "postman_test_lambda" {
-      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.0.1"
+      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.1.0"
         app_name                      = "simple-example"
         postman_collection_file       = "terraform-aws-postman-test-lambda-example.postman_collection.json"
         postman_environment_file      = "terraform-aws-postman-test-lambda-env.postman_environment.json"
@@ -24,7 +24,7 @@ You can provide a postman collection and environment to be tested in one of two 
 2. Or from the Postman API
     ```hcl
     module "postman_test_lambda" {
-      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.0.1"
+      source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v2.1.0"
         app_name                      = "simple-example"
         postman_collection_name       = "terraform-aws-postman-test-lambda-example"
         postman_environment_name      = "terraform-aws-postman-test-lambda-env"
@@ -80,6 +80,7 @@ module "lambda_api" {
 | app_name                      | string      | Application name to prefix your postman test lambda function's name                                                                                  |         |
 | postman_collection_file       | string      | Path to the postman collection JSON file relative from terraform dir (must be provided with postman_environment_file)                                | null    |
 | postman_environment_file      | string      | Path to the postman environment JSON file relative from terraform dir (must be provided with postman_collection_file)                                | null    |
+| postman_files_bucket_name     | string      | S3 Bucket name for the S3 Bucket this module will upload the postman_collection_file and postman_environment_file to                                 | <app_name>-postman-files    |
 | postman_collection_name       | string      | Name of Postman collection to download from Postman API  (must be provided with postman_api_key and postman_environment_name)                        | null    |
 | postman_environment_name      | string      | Name of Postman environment to download from Postman API  (must be provided with postman_api_key and postman_collection_name)                        | null    |
 | postman_api_key               | string      | postman API key to download collection and environment from Postman API (must be provided with postman_collection_name and postman_environment_name) | null    |
@@ -91,6 +92,7 @@ module "lambda_api" {
 | --------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | lambda_function | [object](https://www.terraform.io/docs/providers/aws/r/lambda_function.html#attributes-reference) | Created lambda function that runs newman to test the `postman_collection` |
 | lambda_iam_role | [object](https://www.terraform.io/docs/providers/aws/r/iam_role.html#attributes-reference)        | Created IAM role for the `lambda_function`                                |
+| postman_files_bucket | [object](https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#attributes-reference)  | Created S3 Bucket where local postman files are uploaded                  |
 
 ## Contributing
 To contribute to this terraform module make a feature branch and create a Pull Request to the `master` branch.

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ data aws_caller_identity "current" {}
 resource "aws_s3_bucket" "postman_bucket" {
   count = local.using_local_files ? 1 : 0
 
-  bucket = "${var.app_name}-postman-tests-${data.aws_caller_identity.current.account_id}"
+  bucket = var.postman_files_bucket_name != null ? var.postman_files_bucket_name : "${var.app_name}-postman-files"
   lifecycle_rule {
     id                                     = "AutoAbortFailedMultipartUpload"
     enabled                                = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "lambda_function" {
 output "lambda_iam_role" {
   value = aws_iam_role.test_lambda
 }
+
+output "postman_files_bucket" {
+  value = local.using_local_files ? aws_s3_bucket.postman_bucket[0] : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "postman_environment_file" {
   default     = null
 }
 
+variable "postman_files_bucket_name" {
+  type        = string
+  description = "S3 Bucket name for the S3 Bucket this module will upload the postman_collection_file and postman_environment_file to (defaults to <app_name>-postman-files)"
+  default     = null
+}
+
 variable "postman_collection_name" {
   type        = string
   description = "Name of Postman collection to download from Postman API (must be provided with postman_api_key and postman_environment_name)"


### PR DESCRIPTION
Added a new optional variable to change the s3 bucket name when uploading local collection/env fiels.

I changed the default name from `${var.app_name}-postman-tests-${data.aws_caller_identity.current.account_id}` to `${var.app_name}-postman-files`, is that a breaking change that would likely require a major version release? Or should I keep the default as is and if you want/need a different s3 bucket name you provide it in the variable?