### PR TITLE
Use filebase64sha256 to compute source_code_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This lambda function will tell CodeDeploy if the tests pass or fail.
 
 ```hcl
 module "postman_test_lambda" {
-  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v3.2.0"
+  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v3.2.1"
   app_name = "simple-example"
   postman_collections = [
     {
@@ -85,7 +85,7 @@ selecting your collection/environment and clicking on the info icon.
 
 ```hcl
 module "postman_test_lambda" {
-  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v3.2.0"
+  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v3.2.1"
   app_name = "from-postman-api-example"
   postman_collections = [
     {

--- a/lambda/package-lock.json
+++ b/lambda/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-test-lambda",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lambda/package.json
+++ b/lambda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postman-test-lambda",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Lambda function that runs postman collection tests",
   "repository": {
     "type": "git",

--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ resource "aws_lambda_function" "test_lambda" {
   runtime          = "nodejs14.x"
   timeout          = var.timeout
   memory_size      = var.memory_size
-  source_code_hash = base64sha256("${path.module}/lambda/dist/function.zip")
+  source_code_hash = filebase64sha256("${path.module}/lambda/dist/function.zip")
   environment {
     variables = local.lambda_env_variables
   }


### PR DESCRIPTION
We're moving from [`base64sha256`](https://www.terraform.io/docs/language/functions/base64sha256.html) to [`filebase64sha256`](https://www.terraform.io/docs/language/functions/filebase64sha256.html) to hopefully clear up Terraform plans that think they need to change this Lambda in place because the `source_code_hash` supposedly changed. ([example](https://github.com/byu-oit/hw-fargate-api/runs/3323536741#step:17:232))

I see that [we're already requiring Terraform that's `>= 0.12.6`](https://github.com/byu-oit/terraform-aws-postman-test-lambda/blob/8dfd652b15c704e5dec111c92be0231685125ffd/main.tf#L2). A comment [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function#basic-example) states:
> The filebase64sha256() function is available in Terraform 0.11.12 and later

As such, this should be a patch-version change.
