### PR TITLE
Use newer TF resources for S3 buckets, rather than the now-deprecated resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This lambda function will tell CodeDeploy if the tests pass or fail.
 
 ```hcl
 module "postman_test_lambda" {
-  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v4.0.0"
+  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v4.0.1"
   app_name = "simple-example"
   postman_collections = [
     {
@@ -85,7 +85,7 @@ selecting your collection/environment and clicking on the info icon.
 
 ```hcl
 module "postman_test_lambda" {
-  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v4.0.0"
+  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v4.0.1"
   app_name = "from-postman-api-example"
   postman_collections = [
     {


### PR DESCRIPTION
This is part of an effort to clear up deprecation warnings (see https://github.com/byu-oit/hw-fargate-api/issues/678).

This can be a semver-patch release (https://github.com/byu-oit/hw-fargate-api/pull/688#issuecomment-1291425026), but the change will create some noise in Terraform plans when first introduced.

BTW, this module already requires AWS provider `>= 3.75.2`, so we're not breaking anybody by using the newer resources.