### PR TITLE
bump lambda runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 env:
   tf_version: "1.3.4" # Must be within range specified in main.tf
-  node_version: "16.x"
+  node_version: "20.x"
   TF_IN_AUTOMATION: true
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This lambda function will tell CodeDeploy if the tests pass or fail.
 
 ```hcl
 module "postman_test_lambda" {
-  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v5.0.3"
+  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v6.0.0"
   app_name = "simple-example"
   postman_collections = [
     {
@@ -85,7 +85,7 @@ selecting your collection/environment and clicking on the info icon.
 
 ```hcl
 module "postman_test_lambda" {
-  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v5.0.3"
+  source = "github.com/byu-oit/terraform-aws-postman-test-lambda?ref=v6.0.0"
   app_name = "from-postman-api-example"
   postman_collections = [
     {

--- a/examples/advanced/advanced-example.tf
+++ b/examples/advanced/advanced-example.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.26"
     }
   }
 }

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.26"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = ">= 1.3.0, < 2.0.0"
   required_providers {
-    aws = ">= 4.0.0"
+    aws = ">= 5.26.0"
   }
 }
 
@@ -233,7 +233,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name    = local.lambda_function_name
   role             = aws_iam_role.test_lambda.arn
   handler          = "index.handler"
-  runtime          = "nodejs16.x"
+  runtime          = "nodejs20.x"
   timeout          = var.timeout
   memory_size      = var.memory_size
   source_code_hash = filebase64sha256("${path.module}/lambda/dist/function.zip")


### PR DESCRIPTION
I tried going all the way to node22, but that required upgrading the [AWS provider to 5.77.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5770-november-21-2024), which [introduced other problems](https://github.com/byu-oit/hw-fargate-api/actions/runs/13204516235/job/36864455260#step:13:39). Going to node20 was seamless and will at least [buy us another year](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).
